### PR TITLE
erc20 token immediately proceed to next transaction after approval

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1692,12 +1692,18 @@ function ensureAmountApproved(spender, account, amount) {
                         resolve(allowed);
                     } else {
                         console.log('not enough to cover cost, approving', amount.sub(allowed), spender);
-                        erc20.approve(spender, amount.sub(allowed), {
+                        erc20.approve.sendTransaction(spender, amount.sub(allowed), {
                             from: account,
                             gas: 200000,
                         }).then(function() {
-                            console.log('approval done');
-                            resolve(amount);
+                            // At this point we have received the approval's transaction hash and can proceed with next transaction.
+                            // However, Metamask may need some time to pick up this transaction, 
+                            // which is needed to validate next transactions, and 3 seconds is considered a "safe" waiting time.
+                            // Metamask will still display the error however, but it can be ignored
+                            setTimeout(function() {
+                                console.log('approval done')
+                                resolve(amount);
+                            }, 3000)
                         });
                     }
                 });


### PR DESCRIPTION
Why? To improve perceived performance when transacting with ERC20 token but also potentially avoid user error if he refreshes the page after approval transaction.

[See demo video](https://imgur.com/a/2F1wDuh)

How? Instead of waiting for the approval to be confirmed, we proceed with with ERC20 token transfer once we receive approval's transaction hash. 

There is a caveat, Metamask will **sometimes** display an error for 2nd transaction even though it would still succeed. This is a trade-off between cosmetic flaw versus faster processing time.

@edmundedgar 